### PR TITLE
Use Python 3.6 :bear:

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 Django==1.11a1
 raven==5.32.0
 requests==2.12.3
+whitenoise==3.2.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
 Django==1.11a1
+raven==5.32.0
 requests==2.12.3

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,6 +1,5 @@
 -r base.txt
 dj-database-url==0.4.2
 psycopg2==2.6.2
-raven==5.32.0
 uWSGI==2.0.14
 whitenoise==3.2.3

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,4 +2,3 @@
 dj-database-url==0.4.2
 psycopg2==2.6.2
 uWSGI==2.0.14
-whitenoise==3.2.3

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.6.0

--- a/zendesk_tickets_machine/boards/tests/test_views.py
+++ b/zendesk_tickets_machine/boards/tests/test_views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils.timezone import utc
 
 from ..models import Board, BoardGroup
 from agents.models import Agent
@@ -334,6 +335,9 @@ class BoardSingleViewTest(TestCase):
 
     def test_board_single_view_should_have_date_format(self):
         self.login()
+        due_at = datetime.datetime(2017, 1, 1, 12, 30, 59, 0).replace(
+            tzinfo=utc
+        )
         Ticket.objects.create(
             subject='Ticket 1',
             comment='Comment 1',
@@ -341,7 +345,7 @@ class BoardSingleViewTest(TestCase):
             assignee=self.agent,
             group=self.agent_group,
             ticket_type='question',
-            due_at=datetime.datetime(2017, 1, 1, 12, 30, 59, 0),
+            due_at=due_at,
             priority='urgent',
             tags='welcome',
             private_comment='Private comment',


### PR DESCRIPTION
- Use Python 3.6.
- Move `raven` and `whitenoise` to base requirements.
- Add time zone support when create datetime object in test.