### PR TITLE
Select tickets to create Zendesk tickets

### DIFF
--- a/zendesk_tickets_machine/boards/templates/board_single.html
+++ b/zendesk_tickets_machine/boards/templates/board_single.html
@@ -8,6 +8,9 @@
     height: 30px;
     margin-right: 2px;
   }
+  .btn-is-disabled {
+    pointer-events: none;
+  }
 {% endblock %}
 {% block body %}
 {% spaceless %}
@@ -22,7 +25,7 @@
                 <div class="nav-right is-hidden-mobile">
                   <div class="block">
                     <a class="button modal-button" data-target="#modal-add-ticket"> <span class="icon"><i class="fa fa-plus"></i></span>&nbsp;&nbsp;Add New Ticket</a>&nbsp;
-                    <a href="{% url 'board_tickets_create' board_slug %}" class="button is-success is-outlined">Create Tickets</a>&nbsp;
+                    <a id="create-zendesk-tickets" href="{% url 'board_tickets_create' board_slug %}" class="button is-success is-outlined">Create Tickets</a>&nbsp;
                     <a href="{% url 'board_requesters_reset' board_slug %}" class="button is-warning is-outlined">Reset Requesters</a>&nbsp;
                     <a href="{% url 'board_reset' board_slug %}" class="button is-danger is-outlined">Reset Tickets </a>
                   </div>
@@ -183,6 +186,22 @@
       $("#modal-add-ticket").removeClass("is-active");
       $("#modal-edit-ticket").removeClass("is-active");
     });
+
+    $('.check :checkbox').click(function() {
+      const checked = $('.check :checkbox:checked')
+      const ticket_ids = checked.map(function() {
+        if (this.value !== 'on') {
+          return this.value
+        }
+      }).get()
+
+      const original_href = '{% url "board_tickets_create" board_slug %}'
+      if (ticket_ids.length > 0) {
+        $('#create-zendesk-tickets').attr('href', original_href + '?tickets=' + ticket_ids.join(','))
+      } else {
+        $('#create-zendesk-tickets').attr('href', original_href)
+      }
+    })
   });
 </script>
 <script src="{% static 'js/app.js' %}" type="text/javascript"></script>

--- a/zendesk_tickets_machine/boards/tests/test_views.py
+++ b/zendesk_tickets_machine/boards/tests/test_views.py
@@ -942,6 +942,7 @@ class BoardRequestersResetViewTest(TestCase):
         self.first_ticket = Ticket.objects.create(
             subject='Ticket 1',
             comment='Comment 1',
+            organization='Hiso Tech 1',
             requester='client@hisotech.com',
             created_by=agent,
             assignee=agent,
@@ -957,6 +958,7 @@ class BoardRequestersResetViewTest(TestCase):
         self.second_ticket = Ticket.objects.create(
             subject='Ticket 2',
             comment='Comment 2',
+            organization='Hiso Tech 2',
             requester='client+another@hisotech.com',
             created_by=agent,
             assignee=agent,
@@ -1001,6 +1003,20 @@ class BoardRequestersResetViewTest(TestCase):
             second_ticket.requester,
             'client+another@hisotech.com'
         )
+
+    def test_requesters_reset_view_should_reset_organizations_in_tickets(
+        self
+    ):
+        self.login()
+        self.client.get(
+            reverse('board_requesters_reset', kwargs={'slug': self.board.slug})
+        )
+
+        first_ticket = Ticket.objects.get(id=self.first_ticket.id)
+        self.assertEqual(first_ticket.organization, '')
+
+        second_ticket = Ticket.objects.get(id=self.second_ticket.id)
+        self.assertEqual(second_ticket.organization, 'Hiso Tech 2')
 
     def test_requesters_reset_view_should_redirect_to_board(self):
         self.login()

--- a/zendesk_tickets_machine/boards/tests/test_views.py
+++ b/zendesk_tickets_machine/boards/tests/test_views.py
@@ -578,11 +578,35 @@ class BoardSingleViewTest(TestCase):
         response = self.client.get(
             reverse('board_single', kwargs={'slug': self.board.slug})
         )
-        expected = '<a href="%s" class="button is-success is-outlined">' \
+        expected = '<a id="create-zendesk-tickets" href="%s" ' \
+            'class="button is-success is-outlined">' \
             'Create Tickets</a>' % reverse(
                 'board_tickets_create',
                 kwargs={'slug': self.board.slug}
             )
+        self.assertContains(response, expected, count=1, status_code=200)
+
+    def test_board_single_view_should_have_script_to_append_query_string(self):
+        self.login()
+        response = self.client.get(
+            reverse('board_single', kwargs={'slug': self.board.slug})
+        )
+
+        expected = '.btn-is-disabled {\n    pointer-events: none;'
+        self.assertContains(response, expected, count=1, status_code=200)
+
+        expected = '$(\'.check :checkbox\').click(function() {\n      ' \
+            'const checked = $(\'.check :checkbox:checked\')\n      ' \
+            'const ticket_ids = checked.map(function() {\n        ' \
+            'if (this.value !== \'on\') {\n          ' \
+            'return this.value\n        }\n      }).get()\n\n      ' \
+            'const original_href = \'/pre-production/tickets/\'\n      ' \
+            'if (ticket_ids.length > 0) {\n        ' \
+            '$(\'#create-zendesk-tickets\').attr(\'href\', ' \
+            'original_href + \'?tickets=\' + ' \
+            'ticket_ids.join(\',\'))\n      } else {\n        ' \
+            '$(\'#create-zendesk-tickets\').attr(\'href\', ' \
+            'original_href)\n      }\n    })\n  });'
         self.assertContains(response, expected, count=1, status_code=200)
 
     def test_board_single_view_should_have_reset_requesters_button(self):
@@ -899,7 +923,7 @@ class BoardSingleViewTest(TestCase):
             '<span>Log Out</span></a>'
         self.assertContains(response, expected, status_code=200)
 
-    def test_board_single_view_should_required_login(self):
+    def test_board_single_view_should_require_login(self):
         with self.settings(LOGIN_URL=reverse('login')):
             response = self.client.get(
                 reverse('board_single', kwargs={'slug': self.board.slug})

--- a/zendesk_tickets_machine/boards/views.py
+++ b/zendesk_tickets_machine/boards/views.py
@@ -161,7 +161,10 @@ class BoardSingleView(TemplateView):
 
 class BoardRequestersResetView(View):
     def get(self, request, slug):
-        Ticket.objects.filter(board__slug=slug).update(requester='')
+        Ticket.objects.filter(board__slug=slug).update(
+            requester='',
+            organization=''
+        )
 
         return HttpResponseRedirect(
             reverse('board_single', kwargs={'slug': slug})

--- a/zendesk_tickets_machine/boards/views.py
+++ b/zendesk_tickets_machine/boards/views.py
@@ -183,12 +183,21 @@ class BoardZendeskTicketsCreateView(View):
         zendesk_user = ZendeskRequester()
         zendesk_organization = ZendeskOrganization()
 
-        tickets = Ticket.objects.filter(
-            board__slug=slug,
-            is_active=True
-        ).exclude(
-            zendesk_ticket_id__isnull=False
-        )
+        selected_tickets = request.GET.get('tickets')
+        if selected_tickets:
+            tickets = Ticket.objects.filter(
+                id__in=selected_tickets.split(','),
+                board__slug=slug,
+                is_active=True
+            )
+        else:
+            tickets = Ticket.objects.filter(
+                board__slug=slug,
+                is_active=True
+            )
+
+        tickets = tickets.exclude(zendesk_ticket_id__isnull=False)
+
         for each in tickets:
             if each.assignee is None or each.requester == '':
                 continue
@@ -254,7 +263,6 @@ class BoardZendeskTicketsCreateView(View):
                     data,
                     each.zendesk_ticket_id
                 )
-
             except IndexError:
                 pass
 


### PR DESCRIPTION
Use JavaScript to append the query string to the URL on the "Create Tickets" link. We then use the query string to query tickets to create Zendesk tickets.

Connected to #42.