### PR TITLE
Add requester email to error message :bear:

### DIFF
--- a/zendesk_tickets_machine/boards/tests/test_views.py
+++ b/zendesk_tickets_machine/boards/tests/test_views.py
@@ -1959,6 +1959,7 @@ class BoardZendeskTicketsCreateViewTest(TestCase):
             'users': [{
                 'id': '2',
                 'organization_id': 69969,
+                'email': 'kan@pronto.com',
             }]
         }
         mock_organization.return_value.show.return_value = {
@@ -2070,7 +2071,8 @@ class BoardZendeskTicketsCreateViewTest(TestCase):
         messages = list(response.context['messages'])
         self.assertEqual(len(messages), 1)
 
-        expected_message = 'RecordInvalid: Requester: Pronto is suspended.'
+        expected_message = 'RecordInvalid: Requester: Pronto is suspended. ' \
+            '(kan@pronto.com)'
         self.assertEqual(messages[0].level, MSG.ERROR)
         self.assertEqual(messages[0].message, expected_message)
 

--- a/zendesk_tickets_machine/boards/views.py
+++ b/zendesk_tickets_machine/boards/views.py
@@ -248,11 +248,13 @@ class BoardZendeskTicketsCreateView(View):
                 if ticket:
                     each.zendesk_ticket_id = ticket.get('id')
                 else:
+                    requester_email = requester_result['users'][0]['email']
                     result_error = result.get('error')
                     result_requester = result.get('details').get('requester')
                     for each in result_requester:
                         each_description = each.get('description')
-                        error_message = f'{result_error}: {each_description}'
+                        error_message = f'{result_error}: ' \
+                            f'{each_description} ({requester_email})'
                         messages.error(request, error_message)
                     continue
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Add requester email to error message.

Connected to #83.
